### PR TITLE
Provide required tasks for docker pipelines

### DIFF
--- a/data/required_tasks.yml
+++ b/data/required_tasks.yml
@@ -18,6 +18,21 @@ pipeline-required-tasks:
         - sbom-json-check
         - show-sbom
         - summary
+  docker:
+    - effective_on: "2023-11-11T00:00:00Z"
+      tasks:
+        - buildah
+        - clair-scan
+        - clamav-scan
+        - deprecated-image-check
+        - git-clone
+        - init
+        - prefetch-dependencies
+        - inspect-image
+        - sast-snyk-check
+        - sbom-json-check
+        - show-sbom
+        - summary
   generic:
     - effective_on: "2023-08-31T00:00:00Z"
       tasks:


### PR DESCRIPTION
With the fix from https://issues.redhat.com/browse/EC-53, the process of determining the list of required tasks is now correctly taking into account the labels on the build task. As such, the "docker" type is now used.