### PR TITLE
The inspect-image task is only required as part of the FBC pipeline

### DIFF
--- a/data/required_tasks.yml
+++ b/data/required_tasks.yml
@@ -28,7 +28,6 @@ pipeline-required-tasks:
         - git-clone
         - init
         - prefetch-dependencies
-        - inspect-image
         - sast-snyk-check
         - sbom-json-check
         - show-sbom
@@ -43,7 +42,6 @@ pipeline-required-tasks:
         - git-clone
         - init
         - prefetch-dependencies
-        - inspect-image
         - sast-snyk-check
         - sbom-json-check
         - show-sbom
@@ -58,7 +56,6 @@ pipeline-required-tasks:
         - init
         - prefetch-dependencies
         - s2i-java
-        - inspect-image
         - sast-snyk-check
         - sbom-json-check
         - show-sbom
@@ -73,7 +70,6 @@ pipeline-required-tasks:
         - init
         - prefetch-dependencies
         - s2i-nodejs
-        - inspect-image
         - sast-snyk-check
         - sbom-json-check
         - show-sbom
@@ -87,7 +83,6 @@ required-tasks:
       - clamav-scan
       - git-clone
       - init
-      - inspect-image
       - prefetch-dependencies
       - sast-snyk-check
       - summary


### PR DESCRIPTION
The task is removed from all pipelines and then explicitly added to the FBC pipeline in
https://github.com/redhat-appstudio/build-definitions/pull/630. This PR is to ensure that the change can pass EC checks.