### PR TITLE
feat(RHTAPREL-661): allow Docker's golang image

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -6,6 +6,9 @@ rule_data:
   - registry.access.redhat.com/
   - registry.redhat.io/
   - brew.registry.redhat.io/rh-osbs/openshift-golang-builder
+  # Temporary prefix to address https://github.com/kubernetes/kubernetes/issues/121197
+  # To be removed once go-toolset:1.20 is released with RHEL 9.3
+  - docker.io/library/golang
 
   allowed_step_image_registry_prefixes:
   - quay.io/redhat-appstudio/


### PR DESCRIPTION
To address the issue describe here [1], controller-runtime needs to be upgraded in RHTAP operators. A consequence of this is that Go has to be upgraded to 1.20 as well. The current builder, go-toolset, will nto have support for this version until two weeks from now with the release of RHEL 9.3. Until then, we need to rely on Docker's golang image.