### PR TITLE
Add all variants of buildah task

### DIFF
--- a/data/required_tasks.yml
+++ b/data/required_tasks.yml
@@ -4,7 +4,7 @@ pipeline-required-tasks:
   fbc:
     - effective_on: "2023-08-31T00:00:00Z"
       tasks:
-        - buildah
+        - [buildah, buildah-10gb, buildah-6gb, buildah-8gb, buildah-remote]
         - clair-scan
         - clamav-scan
         - deprecated-image-check
@@ -21,7 +21,7 @@ pipeline-required-tasks:
   generic:
     - effective_on: "2023-08-31T00:00:00Z"
       tasks:
-        - buildah
+        - [buildah, buildah-10gb, buildah-6gb, buildah-8gb, buildah-remote]
         - clair-scan
         - clamav-scan
         - deprecated-image-check


### PR DESCRIPTION
With the https://github.com/enterprise-contract/ec-policies/pull/789 merged we can support 'one of' semantic in required task. This changes the definition of required tasks so one of buildah task variants is required.

reference: https://issues.redhat.com/browse/RHTAPBUGS-914