### PR TITLE
Add `source-build` as a required task to pipelines

### DIFF
--- a/data/required_tasks.yml
+++ b/data/required_tasks.yml
@@ -19,6 +19,20 @@ pipeline-required-tasks:
         - show-sbom
         - summary
   docker:
+    - effective_on: "2023-12-31T00:00:00Z"
+      tasks:
+        - buildah
+        - clair-scan
+        - clamav-scan
+        - deprecated-image-check
+        - git-clone
+        - init
+        - prefetch-dependencies
+        - sast-snyk-check
+        - sbom-json-check
+        - show-sbom
+        - source-build
+        - summary
     - effective_on: "2023-11-11T00:00:00Z"
       tasks:
         - buildah
@@ -33,6 +47,20 @@ pipeline-required-tasks:
         - show-sbom
         - summary
   generic:
+    - effective_on: "2023-12-31T00:00:00Z"
+      tasks:
+        - buildah
+        - clair-scan
+        - clamav-scan
+        - deprecated-image-check
+        - git-clone
+        - init
+        - prefetch-dependencies
+        - sast-snyk-check
+        - sbom-json-check
+        - show-sbom
+        - source-build
+        - summary
     - effective_on: "2023-08-31T00:00:00Z"
       tasks:
         - buildah
@@ -47,6 +75,20 @@ pipeline-required-tasks:
         - show-sbom
         - summary
   java:
+    - effective_on: "2023-12-31T00:00:00Z"
+      tasks:
+        - clair-scan
+        - clamav-scan
+        - deprecated-image-check
+        - git-clone
+        - init
+        - prefetch-dependencies
+        - s2i-java
+        - sast-snyk-check
+        - sbom-json-check
+        - show-sbom
+        - source-build
+        - summary
     - effective_on: "2023-08-31T00:00:00Z"
       tasks:
         - clair-scan
@@ -61,6 +103,20 @@ pipeline-required-tasks:
         - show-sbom
         - summary
   nodejs:
+    - effective_on: "2023-12-31T00:00:00Z"
+      tasks:
+        - clair-scan
+        - clamav-scan
+        - deprecated-image-check
+        - git-clone
+        - init
+        - prefetch-dependencies
+        - s2i-nodejs
+        - sast-snyk-check
+        - sbom-json-check
+        - show-sbom
+        - source-build
+        - summary
     - effective_on: "2023-08-31T00:00:00Z"
       tasks:
         - clair-scan
@@ -77,6 +133,16 @@ pipeline-required-tasks:
 
 # https://enterprisecontract.dev/docs/ec-policies/release_policy.html#tasks_package
 required-tasks:
+  - effective_on: "2023-12-31T00:00:00Z"
+    tasks:
+      - clair-scan
+      - clamav-scan
+      - git-clone
+      - init
+      - prefetch-dependencies
+      - sast-snyk-check
+      - source-build
+      - summary
   - effective_on: "2023-08-31T00:00:00Z"
     tasks:
       - clair-scan


### PR DESCRIPTION
This commit adds `source-build` as a required task to pipeline-required-tasks as appropriate.

Resolves: EC-233