### PR TITLE
Revert "Don't allow releases on fridays or weekends, don't allow duri…

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -110,19 +110,3 @@ rule_data:
   # https://enterprisecontract.dev/docs/ec-policies/release_policy.html#test_package
   informative_tests:
   - sast-snyk-check
-
-  # Basic rule of no releases on Fridays/Weekends
-  disallowed_weekdays:
-  - friday
-  - saturday
-  - sunday
-
-  # Don't allow releases during winter shutdown, friday-weekend already blocked
-  disallowed_dates:
-  - 2023-12-21
-  - 2023-12-25
-  - 2023-12-26
-  - 2023-12-27
-  - 2023-12-28
-  - 2024-01-01
-  


### PR DESCRIPTION
…ng shutdown"

This reverts commit 0d10f423a944df36f45f707ee2a1588927e25e5b.

This restriction is incorrectly being applied to everything, including PRs which was not the intention. Let's revert it for now and come up with an alternative.