### PR TITLE
Make sure to include all buildah variants

### DIFF
--- a/data/required_tasks.yml
+++ b/data/required_tasks.yml
@@ -21,7 +21,7 @@ pipeline-required-tasks:
   docker:
     - effective_on: "2023-12-31T00:00:00Z"
       tasks:
-        - buildah
+        - [buildah, buildah-10gb, buildah-6gb, buildah-8gb, buildah-remote]
         - clair-scan
         - clamav-scan
         - deprecated-image-check
@@ -49,7 +49,7 @@ pipeline-required-tasks:
   generic:
     - effective_on: "2023-12-31T00:00:00Z"
       tasks:
-        - buildah
+        - [buildah, buildah-10gb, buildah-6gb, buildah-8gb, buildah-remote]
         - clair-scan
         - clamav-scan
         - deprecated-image-check


### PR DESCRIPTION
The new policy went into effect with the new year and it doesn't contain all the variants of the buildah task. This adds them.