### PR TITLE
Remove irrelevant step image

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -11,11 +11,7 @@ rule_data:
   - quay.io/redhat-appstudio/
   - registry.access.redhat.com/
   - registry.redhat.io/
-  # Due to https://issues.redhat.com/browse/OCPBUGS-8428 images from registry.redhat.io may
-  # sometimes be reported as coming from the repository below. This is a temporary workaround
-  # until the JIRA is resolved.
-  - quay.io/openshift-release-dev/ocp-v4.0-art-dev
-  # Allow prelight images to be used in rhtap / konflux 
+  # Allow prelight images to be used in rhtap / konflux
   # Documentation link: https://github.com/redhat-openshift-ecosystem/openshift-preflight/blob/main/docs/RECIPES.md
   - quay.io/opdev/preflight
 


### PR DESCRIPTION
As the comment suggests, the
quay.io/openshift-release-dev/ocp-v4.0-art-dev was added as a workaround to an OCP issue. The policy rule that uses this data has been moved from the "release" namespace to the "task" namespace. This means the policy rule applies to a Task definition instead of the Task information captured in the SLSA Provenance attestation. The check is now executed as part of the build-definitions CI on the Task definitions directly.

At some point, we may want to execute the check against the information in the SLSA Provenance attestation but currently this is not possible. https://issues.redhat.com/browse/RFE-4608 will hopefully turn this into reality.