### PR TITLE
Remove sbom-json-check from required tasks

### DIFF
--- a/data/required_tasks.yml
+++ b/data/required_tasks.yml
@@ -11,7 +11,6 @@ pipeline-required-tasks:
         - git-clone
         - init
         - inspect-image
-        - sbom-json-check
         - show-sbom
         - summary
   docker:
@@ -25,7 +24,6 @@ pipeline-required-tasks:
         - init
         - prefetch-dependencies
         - sast-snyk-check
-        - sbom-json-check
         - show-sbom
         - source-build
         - summary
@@ -53,7 +51,6 @@ pipeline-required-tasks:
         - init
         - prefetch-dependencies
         - sast-snyk-check
-        - sbom-json-check
         - show-sbom
         - source-build
         - summary
@@ -81,7 +78,6 @@ pipeline-required-tasks:
         - prefetch-dependencies
         - s2i-java
         - sast-snyk-check
-        - sbom-json-check
         - show-sbom
         - source-build
         - summary
@@ -109,7 +105,6 @@ pipeline-required-tasks:
         - prefetch-dependencies
         - s2i-nodejs
         - sast-snyk-check
-        - sbom-json-check
         - show-sbom
         - source-build
         - summary


### PR DESCRIPTION
Removing the task sbom-json-check for the current set of required tasks. The EC policies should be checking for valid SBOMs anyway so this check is unnecessarily duplicated.