### PR TITLE
Allow quay.io/konflux-ci/ for step images

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -9,6 +9,7 @@ rule_data:
 
   allowed_step_image_registry_prefixes:
   - quay.io/redhat-appstudio/
+  - quay.io/konflux-ci/
   - registry.access.redhat.com/
   - registry.redhat.io/
   # Allow prelight images to be used in rhtap / konflux


### PR DESCRIPTION
https://quay.io/repository/konflux-ci/oras?tab=tags&tag=latest is the first one, for https://github.com/redhat-appstudio/build-definitions/pull/992