### PR TITLE
enabling steps from quay.io/redhat-appstudio-tekton-catalog/

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -9,6 +9,7 @@ rule_data:
 
   allowed_step_image_registry_prefixes:
   - quay.io/redhat-appstudio/
+  - quay.io/redhat-appstudio-tekton-catalog/
   - quay.io/konflux-ci/
   - registry.access.redhat.com/
   - registry.redhat.io/


### PR DESCRIPTION
With the bump of the deprecated image check to version `0.4` from `0.3`, we are seeing a lot of new errors in our EC. One such set of errors is the `Trusted` section, listing that all of our tasks are using untrusted refrerences: `Pipeline task <task_name> uses an untrusted task reference, oci://quay.io/redhat-appstudio-tekton-catalog/<task_name>`. This PR should allow steps from: `quay.io/redhat-appstudio-tekton-catalog`. Not sure if I should remove [quay.io/redhat-appstudio/](https://github.com/release-engineering/rhtap-ec-policy/blob/main/data/rule_data.yml#L11), or if not every task has been migrated.