### PR TITLE
Mark sast-snyk-check TA alternative as informative

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -114,6 +114,7 @@ rule_data:
   # https://enterprisecontract.dev/docs/ec-policies/release_policy.html#test_package
   informative_tests:
   - sast-snyk-check
+  - sast-snyk-check-oci-ta
 
   disallowed_packages:
   # Disallow hashicorp packages with restrictive licenses.


### PR DESCRIPTION
The sast-snyk-check test is marked as an informative test. This means it is ok if it emits failures, as long as it was able execute. There is a variation of the check that supports Trusted Artifacts.

This commit marks the sast-snyk-check-oci-ta test as an information test.