### PR TITLE
Make ecosytem preflight failures non-blocking

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -115,6 +115,7 @@ rule_data:
   informative_tests:
   - sast-snyk-check
   - sast-snyk-check-oci-ta
+  - ecosystem-cert-preflight-checks
 
   disallowed_packages:
   # Disallow hashicorp packages with restrictive licenses.


### PR DESCRIPTION
I'm not sure about the pros and cons of this, but there are several teams who get surprised by this failure and want to exclude it.

Because the task itself it not included in the required task lists, removing it entirely from the pipeline gets EC to pass. So for that reason I'm assuming it's acceptable to make it non-blocking.

(The downside is that it's going to be much easier to ignore any failures produced by this test.)

[This PR](https://github.com/konflux-ci/build-definitions/pull/556) has some useful context. The original intention was that the test should not be a hard requirement to begin with, which I think supports the goal of this PR.