### PR TITLE
Add disallowed_platform_patterns

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -211,3 +211,7 @@ rule_data:
   - features.operators.openshift.io/token-auth-aws
   - features.operators.openshift.io/token-auth-azure
   - features.operators.openshift.io/token-auth-gcp
+
+  disallowed_platform_patterns:
+  - .*root.*
+


### PR DESCRIPTION
As part of EC-726, a new policy rule,
`buildah_build_task.platform_param`,  was added to prevent certain platforms from being used based on the value of the `disallowed_platform_patterns` rule data.

This commit disallows using platforms that include the `root` string. This is the convention used to specify rootful hosts.

For the workflows that do require rootful access, use a policy config that either disables the policy rule, or overrides the value of the rule data to an empty list.

Ref: EC-726