### PR TITLE
Add features annotations to rule data

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -198,3 +198,16 @@ rule_data:
   - 2025-12-30
   - 2025-12-31
   - 2026-01-01
+
+# Usage: https://enterprisecontract.dev/docs/ec-policies/release_policy.html#olm__required_olm_features_annotations_provided
+  required_olm_features_annotations:
+  - features.operators.openshift.io/disconnected
+  - features.operators.openshift.io/fips-compliant
+  - features.operators.openshift.io/proxy-aware
+  - features.operators.openshift.io/cnf
+  - features.operators.openshift.io/cni
+  - features.operators.openshift.io/csi
+  - features.operators.openshift.io/tls-profiles
+  - features.operators.openshift.io/token-auth-aws
+  - features.operators.openshift.io/token-auth-azure
+  - features.operators.openshift.io/token-auth-gcp


### PR DESCRIPTION
Added required_olm_features_annotations data to rule data.

It came up in an ec-policies [PR review](https://github.com/enterprise-contract/ec-policies/pull/1092#discussion_r1697515781) that `required_olm_features_annotations` was missing from the rule data.