### PR TITLE
Require specific value for vendor label

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -78,6 +78,8 @@ rule_data:
       Generally one of git, hg, svn, bzr, cvs
   - name: vendor
     description: Name of the vendor.
+    values:
+    - 'Red Hat, Inc.'
   - name: version
     description: Version of the image.
 


### PR DESCRIPTION
Currently, the EC CLI behaves differently if the vendor label is set to the value `Red Hat, Inc.`. If so, it downloads certain files from within the image and makes them available for processing by the rego policy rules. If the image uses a different value for this label then those files are not available. This often causes confusion to users and to most of us analyzing those failures. This change increases visibility for such cases.

Ref: https://issues.redhat.com/browse/EC-787