### PR TITLE
Add nvidia cuda registry to allowed_registry_prefixes

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -6,6 +6,7 @@ rule_data:
   - registry.access.redhat.com/
   - registry.redhat.io/
   - brew.registry.redhat.io/rh-osbs/openshift-golang-builder
+  - nvcr.io/nvidia/cuda
 
   allowed_step_image_registry_prefixes:
   - quay.io/redhat-appstudio/


### PR DESCRIPTION
Our images have to include NVIDIA CUDA libraries, therefore we use `[nvcr.io/nvidia/cuda:12.6.0-base-ubi8](http://nvcr.io/nvidia/cuda:12.6.0-base-ubi8)` as our base image. It was meant by NVIDIA for exactly such cases (the image description https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda/tags).

This PR adds the official NVIDIA registry to allowed_registry_prefixes.

More info in this slack thread - https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1725956705929099?thread_ts=1725956704.766019&cid=C04PZ7H0VA8 

/cc @empovit
