### PR TITLE
Disallow externalReferences of type distribution by default

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -222,3 +222,9 @@ rule_data:
   # release key 2
   - 199e2f91fd431d51
 
+  # No packages with externalReferences of type distribution
+  # https://enterprisecontract.dev/docs/ec-policies/release_policy.html#sbom_cyclonedx__allowed_package_external_references
+  allowed_external_references:
+  - type: "distribution"
+    url: "^$"
+


### PR DESCRIPTION
This change would forbid any packages with externalReferences of type `distribution` by default. This would be done in order to restrict packages from unknown sources, particularly those fetched with cachi2's planned generic pre-fetching functionality (https://github.com/containerbuildsystem/cachi2/pull/652). 

