### PR TITLE
Allow hashcorp/vault/{api,sdk} golang submodules

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -136,6 +136,10 @@ rule_data:
     format: semverv
     # https://github.com/hashicorp/vault/blob/8a46bee76887523a006410d1e865f5365e709851/LICENSE#L7
     min: v1.15.0
+    exceptions:
+      # The api and sdk submodules have a different license.
+      - subpath: api
+      - subpath: sdk
   - purl: pkg:golang/github.com/hashicorp/vagrant
     format: semverv
     # https://github.com/hashicorp/vagrant/blob/ac6374cd11a51b6992a5dc981bf617db74b4ca7d/LICENSE#L7


### PR DESCRIPTION
The hashicorp/vault module has some problematic licensing, but the submodules are MPL 2.0 so they should be okay.

Similar to #51.

Ref: https://issues.redhat.com/browse/EC-920