### PR TITLE
Drop rpms-signature-scan from fbc required tasks

### DIFF
--- a/data/required_tasks.yml
+++ b/data/required_tasks.yml
@@ -11,7 +11,6 @@ pipeline-required-tasks:
         - [git-clone, git-clone-oci-ta]
         - init
         - inspect-image
-        - rpms-signature-scan
         - show-sbom
     - effective_on: "2024-06-17T00:00:00Z"
       tasks:


### PR DESCRIPTION
FBC images are "catalog fragments" that are never actually shipped. They only exist to convey data to the process that updates the global index image. It is unreasonable to scan them for rpm content.

Even if they somehow included unsigned rpm content, that content is never going to be exposed.