### PR TITLE
Allows cachi2 downloads from indy.corp.redhat.com

### DIFF
--- a/data/allowed_package_sources.yml
+++ b/data/allowed_package_sources.yml
@@ -1,0 +1,6 @@
+---
+rule_data:
+  allowed_package_sources:
+    - type: generic
+      patterns:
+        - https://indy\.corp\.redhat\.com.*


### PR DESCRIPTION
This configures EC policy to allow download from any repository on indy.corp.redhat.com, I dont know if this is too wide, perhaps it needs to be narrower, e.g. scoped to

    indy.corp.redhat.com/api/content/maven/hosted/pnc-builds