### PR TITLE
Warn of outdated tasks until 14 days prior expiry

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -17,6 +17,10 @@ rule_data:
   - quay.io/opdev/preflight
   - quay.io/redhat-services-prod/sast/coverity
 
+  # Number of days before a version of the Task expires that warnings are reported
+  # See https://enterprisecontract.dev/docs/ec-policies/release_policy.html#trusted_task__current
+  task_expiry_warning_days: 14
+
   allowed_java_component_sources:
   - redhat
   - rebuilt


### PR DESCRIPTION
With https://issues.redhat.com/browse/EC-944 outdated task warning can be refrained until the task is to expire in a configured amount of days.

This sets that configuration setting to 14 days, so folk should not get warnings until two weeks before the task expires.

Reference: https://issues.redhat.com/browse/EC-944