### PR TITLE
Add three new sast scans to required tasks

### DIFF
--- a/data/required_tasks.yml
+++ b/data/required_tasks.yml
@@ -29,6 +29,21 @@ pipeline-required-tasks:
         - inspect-image
         - summary
   docker:
+    - effective_on: "2025-03-01T00:00:00Z"
+      tasks:
+        - [buildah, buildah-10gb, buildah-6gb, buildah-8gb, buildah-remote, buildah-oci-ta, buildah-remote-oci-ta]
+        - clair-scan
+        - clamav-scan
+        - deprecated-image-check
+        - [git-clone, git-clone-oci-ta]
+        - init
+        - [prefetch-dependencies, prefetch-dependencies-oci-ta]
+        - rpms-signature-scan
+        - [sast-coverity-check, sast-coverity-check-oci-ta]
+        - [sast-shell-check, sast-shell-check-oci-ta]
+        - [sast-snyk-check, sast-snyk-check-oci-ta]
+        - [sast-unicode-check, sast-unicode-check-oci-ta]
+        - [source-build, source-build-oci-ta]
     - effective_on: "2024-11-01T00:00:00Z"
       tasks:
         - [buildah, buildah-10gb, buildah-6gb, buildah-8gb, buildah-remote, buildah-oci-ta, buildah-remote-oci-ta]
@@ -65,6 +80,21 @@ pipeline-required-tasks:
         - source-build
         - summary
   generic:
+    - effective_on: "2025-03-01T00:00:00Z"
+      tasks:
+        - [buildah, buildah-10gb, buildah-6gb, buildah-8gb, buildah-remote, buildah-oci-ta, buildah-remote-oci-ta]
+        - clair-scan
+        - clamav-scan
+        - deprecated-image-check
+        - [git-clone, git-clone-oci-ta]
+        - init
+        - [prefetch-dependencies, prefetch-dependencies-oci-ta]
+        - rpms-signature-scan
+        - [sast-coverity-check, sast-coverity-check-oci-ta]
+        - [sast-shell-check, sast-shell-check-oci-ta]
+        - [sast-snyk-check, sast-snyk-check-oci-ta]
+        - [sast-unicode-check, sast-unicode-check-oci-ta]
+        - [source-build, source-build-oci-ta]
     - effective_on: "2024-11-01T00:00:00Z"
       tasks:
         - [buildah, buildah-10gb, buildah-6gb, buildah-8gb, buildah-remote, buildah-oci-ta, buildah-remote-oci-ta]
@@ -101,6 +131,21 @@ pipeline-required-tasks:
         - source-build
         - summary
   java:
+    - effective_on: "2025-03-01T00:00:00Z"
+      tasks:
+        - clair-scan
+        - clamav-scan
+        - deprecated-image-check
+        - [git-clone, git-clone-oci-ta]
+        - init
+        - [prefetch-dependencies, prefetch-dependencies-oci-ta]
+        - rpms-signature-scan
+        - s2i-java
+        - [sast-coverity-check, sast-coverity-check-oci-ta]
+        - [sast-shell-check, sast-shell-check-oci-ta]
+        - [sast-snyk-check, sast-snyk-check-oci-ta]
+        - [sast-unicode-check, sast-unicode-check-oci-ta]
+        - [source-build, source-build-oci-ta]
     - effective_on: "2024-11-01T00:00:00Z"
       tasks:
         - clair-scan
@@ -137,6 +182,21 @@ pipeline-required-tasks:
         - source-build
         - summary
   nodejs:
+    - effective_on: "2025-03-01T00:00:00Z"
+      tasks:
+        - clair-scan
+        - clamav-scan
+        - deprecated-image-check
+        - [git-clone, git-clone-oci-ta]
+        - init
+        - [prefetch-dependencies, prefetch-dependencies-oci-ta]
+        - rpms-signature-scan
+        - s2i-nodejs
+        - [sast-coverity-check, sast-coverity-check-oci-ta]
+        - [sast-shell-check, sast-shell-check-oci-ta]
+        - [sast-snyk-check, sast-snyk-check-oci-ta]
+        - [sast-unicode-check, sast-unicode-check-oci-ta]
+        - [source-build, source-build-oci-ta]
     - effective_on: "2024-11-01T00:00:00Z"
       tasks:
         - clair-scan
@@ -175,6 +235,19 @@ pipeline-required-tasks:
 
 # https://enterprisecontract.dev/docs/ec-policies/release_policy.html#tasks_package
 required-tasks:
+  - effective_on: "2025-03-01T00:00:00Z"
+    tasks:
+      - clair-scan
+      - clamav-scan
+      - [git-clone, git-clone-oci-ta]
+      - init
+      - [prefetch-dependencies, prefetch-dependencies-oci-ta]
+      - rpms-signature-scan
+      - [sast-coverity-check, sast-coverity-check-oci-ta]
+      - [sast-shell-check, sast-shell-check-oci-ta]
+      - [sast-snyk-check, sast-snyk-check-oci-ta]
+      - [sast-unicode-check, sast-unicode-check-oci-ta]
+      - [source-build, source-build-oci-ta]
   - effective_on: "2024-11-01T00:00:00Z"
     tasks:
       - clair-scan

--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -120,9 +120,15 @@ rule_data:
 
   # https://enterprisecontract.dev/docs/ec-policies/release_policy.html#test_package
   informative_tests:
+  - ecosystem-cert-preflight-checks
+  - sast-coverity-check
+  - sast-coverity-check-oci-ta
+  - sast-shell-check
+  - sast-shell-check-oci-ta
   - sast-snyk-check
   - sast-snyk-check-oci-ta
-  - ecosystem-cert-preflight-checks
+  - sast-unicode-check
+  - sast-unicode-check-oci-ta
 
   disallowed_packages:
   # Disallow hashicorp packages with restrictive licenses.


### PR DESCRIPTION
Use an effective on date of March 1st to give people time to get them added them to their pipeline definitions.

Note the tests will be required, meaning if they're not included EC will produce a "required task not found" violation, but they are "informative" only, meaning if they produce a failure status, EC will not produce a violation.

I didn't add the new tasks to the fbc pipeline required task list since I think sast scans are likely not useful there, and because the existing sast-snyk-check scan is already not required for fbc.

Handy queries to help confirm this change:
```
yq '.pipeline-required-tasks | to_entries[].value |[.[0].tasks - .[1].tasks]' data/required_tasks.yml
yq '.required-tasks|[.[0].tasks - .[1].tasks]' data/required_tasks.yml
```

Ref: https://issues.redhat.com/browse/EC-887
Ref: https://issues.redhat.com/browse/EC-888
Ref: https://issues.redhat.com/browse/EC-889