### PR TITLE
rules: Drop `architecture` and `build-date` from required container labels

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -53,10 +53,6 @@ rule_data:
 
   # https://enterprisecontract.dev/docs/ec-policies/release_policy.html#labels__required_labels
   required_labels:
-  - name: architecture
-    description: Architecture the software in the image should target.
-  - name: build-date
-    description: Date/Time image was built as RFC 3339 date-time.
   - name: com.redhat.component
     description: The Bugzilla component name where bugs against this container should be reported by users.
   - name: description


### PR DESCRIPTION
(OCI/Docker) containers have a long history, and Red Hat was there in the early days, before things were standardized as OCI even - and especially before things like manifest lists and also the standard annotation keys: https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys

There are two labels this policy requires that duplicate standard metadata.

- `architecture`: This is already handled via manifest listing and is part of the config
- `build-date`: There's a standard `Created` field

As these are basically legacy from old Red Hat build systems we are just cargo culting forward for as far as I know no good reason, let's stop doing that.

Signed-off-by: Colin Walters <walters@verbum.org>