### PR TITLE
Allow quay.io/konflux-ci/yq as a base image

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -6,6 +6,7 @@ rule_data:
   - registry.access.redhat.com/
   - registry.redhat.io/
   - brew.registry.redhat.io/rh-osbs/openshift-golang-builder
+  - quay.io/konflux-ci/yq
 
   allowed_step_image_registry_prefixes:
   - quay.io/redhat-appstudio/


### PR DESCRIPTION
We agreed that it is permissible because it is built hermetically.