### PR TITLE
allowed_java_component_sources needs at least one entry

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -23,6 +23,9 @@ rule_data:
   # See https://enterprisecontract.dev/docs/ec-policies/release_policy.html#trusted_task__current
   task_expiry_warning_days: 14
 
+  allowed_java_component_sources:
+  - none
+  
   pipeline_run_params:
   - git-repo
   - git-revision


### PR DESCRIPTION
Policy violations were failing with errors like:

```
✕ [Violation] java.trusted_dependencies_source_list_provided
  Reason: Rule data allowed_java_component_sources has unexpected format: (Root): Array must have at least 1 items
  Title: Trusted Java dependency source list was provided
  Description: Confirm the `allowed_java_component_sources` rule data was provided, since it's required by the policy rules in
  this package. To exclude this rule add "java.trusted_dependencies_source_list_provided" to the `exclude` section of the policy
  configuration.
  Solution: Add a data source that contains allowable source repositories for build dependencies. The source must be located under
  a key named 'allowed_java_component_sources'. More information on adding xref:ec-cli:ROOT:configuration.adoc#_data_sources[data
  sources].
```

In order to unblock all users referencing this policy, I am proposing to add the data back in for now until it can be properly removed.