### PR TITLE
Use Konflux prod policy bundle to validate data

### DIFF
--- a/hack/verify-data.sh
+++ b/hack/verify-data.sh
@@ -16,23 +16,30 @@ if [[ -n "${outdated}" && "${outdated}" != "[]" ]]; then
 fi
 echo '✅ data/known_rpm_repositories.yml has expected extras'
 
-# The EC policy does not allow for relative paths. For this reason, we use envsubst to replace
-# occurrences of $PWD with the actual working directory. The result is a temporary policy file
-# with absolute paths.
-# NOTE: An alternative to saving the modified policy to a temporary file is to use a heredoc, e.g.
-# `ec validate input --file <(...)` However, when doing so, the file name is something like
-# `/dev/fd/63` which EC does not understand as neither a JSON nor a YAML file. Instead EC tries to
-# fetch such resource from a Kubernetes cluster 😅
-POLICY_YAML="$(mktemp --suffix '.yaml')"
-< policy.yaml envsubst '$PWD' > "${POLICY_YAML}"
+# The konflux tag is what is used in Konflux prod. It is updated weekly. For reference:
+# https://github.com/redhat-appstudio/infra-deployments/blob/main/components/enterprise-contract/ecp.yaml
+# https://github.com/enterprise-contract/infra-deployments-ci/blob/main/.github/workflows/konflux-policy.yaml
+# Check against them both to potentially catch an immediate breakage and a future breakage.
+for tag in konflux latest; do
 
-ec validate policy --policy "${POLICY_YAML}"
-echo '✅ Policy config validated'
+  # The EC policy does not allow for relative paths. For this reason, we use envsubst to replace
+  # occurrences of $PWD with the actual working directory. The result is a temporary policy file
+  # with absolute paths.
+  # NOTE: An alternative to saving the modified policy to a temporary file is to use a heredoc, e.g.
+  # `ec validate input --file <(...)` However, when doing so, the file name is something like
+  # `/dev/fd/63` which EC does not understand as neither a JSON nor a YAML file. Instead EC tries to
+  # fetch such resource from a Kubernetes cluster 😅
+  POLICY_YAML="$(mktemp --suffix '.yaml')"
+  < policy.yaml env POLICY_TAG=$tag envsubst '$PWD,$POLICY_TAG' > "${POLICY_YAML}"
 
-# The command requires --file to be used at least once. This sets the input to be verified by the
-# policy rules. However, here we are verifying the data sources which does not require an input.
-# So we use a dummy input file instead.
-ec validate input --policy "${POLICY_YAML}" --output yaml --file <(echo '{}') | yq .
-echo '✅ Data validated'
+  ec validate policy --policy "${POLICY_YAML}"
+  echo "✅ Policy config validated ($tag tag)"
 
-rm -f "${POLICY_YAML}"
+  # The command requires --file to be used at least once. This sets the input to be verified by the
+  # policy rules. However, here we are verifying the data sources which does not require an input.
+  # So we use a dummy input file instead.
+  ec validate input --policy "${POLICY_YAML}" --output yaml --file <(echo '{}') | yq .
+  echo "✅ Data validated ($tag tag)"
+
+  rm -f "${POLICY_YAML}"
+done

--- a/policy.yaml
+++ b/policy.yaml
@@ -5,8 +5,12 @@ description: >-
   repository.
 sources:
   - policy:
-      - github.com/enterprise-contract/ec-policies//policy/lib
-      - github.com/enterprise-contract/ec-policies//policy/release
+      # Expecting $POLICY_TAG to be envsubst'ed to either konflux or latest
+      - oci::quay.io/enterprise-contract/ec-release-policy:$POLICY_TAG
+
+      # Use this instead if you want to run against the latest from git
+      #- github.com/enterprise-contract/ec-policies//policy/lib?ref=main
+      #- github.com/enterprise-contract/ec-policies//policy/release?ref=main
     data:
       - $PWD/data
     config:


### PR DESCRIPTION
Rather than validate the data against the very latest main branch of ec-policies, it's potentially more useful to use the same policy bundle that Konflux prod is using.

This might help reduce the chance of a data change breaking Konflux production because it depends on a fresh ec-policies change that hasn't yet rolled out.