### PR TITLE
Extend deadline for new sast tasks

### DIFF
--- a/data/required_tasks.yml
+++ b/data/required_tasks.yml
@@ -37,7 +37,7 @@ pipeline-required-tasks:
         - inspect-image
         - summary
   docker:
-    - effective_on: "2025-03-01T00:00:00Z"
+    - effective_on: "2025-04-01T00:00:00Z"
       tasks:
         - [buildah, buildah-10gb, buildah-6gb, buildah-8gb, buildah-remote, buildah-oci-ta, buildah-remote-oci-ta]
         - clair-scan
@@ -88,7 +88,7 @@ pipeline-required-tasks:
         - source-build
         - summary
   generic:
-    - effective_on: "2025-03-01T00:00:00Z"
+    - effective_on: "2025-04-01T00:00:00Z"
       tasks:
         - [buildah, buildah-10gb, buildah-6gb, buildah-8gb, buildah-remote, buildah-oci-ta, buildah-remote-oci-ta]
         - clair-scan
@@ -139,7 +139,7 @@ pipeline-required-tasks:
         - source-build
         - summary
   nodejs:
-    - effective_on: "2025-03-01T00:00:00Z"
+    - effective_on: "2025-04-01T00:00:00Z"
       tasks:
         - clair-scan
         - clamav-scan
@@ -192,7 +192,7 @@ pipeline-required-tasks:
 
 # https://enterprisecontract.dev/docs/ec-policies/release_policy.html#tasks_package
 required-tasks:
-  - effective_on: "2025-03-01T00:00:00Z"
+  - effective_on: "2025-04-01T00:00:00Z"
     tasks:
       - clair-scan
       - clamav-scan


### PR DESCRIPTION
The work to generate PRs to add the new SAST tasks is behind schedule. See EC-1063 for more details.

It's generally working but it's needs a bit more work and testing before it's ready for production use. Also I'd like to have the email notifications and announcements sent, and the generated PRs created, well ahead of the deadline, to give teams have enough time to respond, and so we have enough time to deal with edge cases and unexpected problems.

Ref: https://issues.redhat.com/browse/EC-1063
Ref: https://issues.redhat.com/browse/KONFLUX-2264