### PR TITLE
drop prefetch dependency from required checks

### DIFF
--- a/data/required_tasks.yml
+++ b/data/required_tasks.yml
@@ -45,7 +45,6 @@ pipeline-required-tasks:
         - deprecated-image-check
         - [git-clone, git-clone-oci-ta]
         - init
-        - [prefetch-dependencies, prefetch-dependencies-oci-ta]
         - rpms-signature-scan
         - [sast-coverity-check, sast-coverity-check-oci-ta]
         - [sast-shell-check, sast-shell-check-oci-ta]
@@ -60,7 +59,6 @@ pipeline-required-tasks:
         - deprecated-image-check
         - [git-clone, git-clone-oci-ta]
         - init
-        - [prefetch-dependencies, prefetch-dependencies-oci-ta]
         - rpms-signature-scan
         - [sast-snyk-check, sast-snyk-check-oci-ta]
         - [source-build, source-build-oci-ta]
@@ -72,7 +70,6 @@ pipeline-required-tasks:
         - deprecated-image-check
         - [git-clone, git-clone-oci-ta]
         - init
-        - [prefetch-dependencies, prefetch-dependencies-oci-ta]
         - [sast-snyk-check, sast-snyk-check-oci-ta]
         - [source-build, source-build-oci-ta]
     - effective_on: "2023-12-31T00:00:00Z"
@@ -83,7 +80,6 @@ pipeline-required-tasks:
         - deprecated-image-check
         - git-clone
         - init
-        - prefetch-dependencies
         - sast-snyk-check
         - source-build
         - summary
@@ -96,7 +92,6 @@ pipeline-required-tasks:
         - deprecated-image-check
         - [git-clone, git-clone-oci-ta]
         - init
-        - [prefetch-dependencies, prefetch-dependencies-oci-ta]
         - rpms-signature-scan
         - [sast-coverity-check, sast-coverity-check-oci-ta]
         - [sast-shell-check, sast-shell-check-oci-ta]
@@ -111,7 +106,6 @@ pipeline-required-tasks:
         - deprecated-image-check
         - [git-clone, git-clone-oci-ta]
         - init
-        - [prefetch-dependencies, prefetch-dependencies-oci-ta]
         - rpms-signature-scan
         - [sast-snyk-check, sast-snyk-check-oci-ta]
         - [source-build, source-build-oci-ta]
@@ -123,7 +117,6 @@ pipeline-required-tasks:
         - deprecated-image-check
         - [git-clone, git-clone-oci-ta]
         - init
-        - [prefetch-dependencies, prefetch-dependencies-oci-ta]
         - [sast-snyk-check, sast-snyk-check-oci-ta]
         - [source-build, source-build-oci-ta]
     - effective_on: "2023-12-31T00:00:00Z"
@@ -134,7 +127,6 @@ pipeline-required-tasks:
         - deprecated-image-check
         - git-clone
         - init
-        - prefetch-dependencies
         - sast-snyk-check
         - source-build
         - summary
@@ -146,7 +138,6 @@ pipeline-required-tasks:
         - deprecated-image-check
         - [git-clone, git-clone-oci-ta]
         - init
-        - [prefetch-dependencies, prefetch-dependencies-oci-ta]
         - rpms-signature-scan
         - s2i-nodejs
         - [sast-coverity-check, sast-coverity-check-oci-ta]
@@ -161,7 +152,6 @@ pipeline-required-tasks:
         - deprecated-image-check
         - [git-clone, git-clone-oci-ta]
         - init
-        - [prefetch-dependencies, prefetch-dependencies-oci-ta]
         - rpms-signature-scan
         - s2i-nodejs
         - [sast-snyk-check, sast-snyk-check-oci-ta]
@@ -173,7 +163,6 @@ pipeline-required-tasks:
         - deprecated-image-check
         - [git-clone, git-clone-oci-ta]
         - init
-        - [prefetch-dependencies, prefetch-dependencies-oci-ta]
         - s2i-nodejs
         - [sast-snyk-check, sast-snyk-check-oci-ta]
         - [source-build, source-build-oci-ta]
@@ -184,7 +173,6 @@ pipeline-required-tasks:
         - deprecated-image-check
         - git-clone
         - init
-        - prefetch-dependencies
         - s2i-nodejs
         - sast-snyk-check
         - source-build
@@ -198,7 +186,6 @@ required-tasks:
       - clamav-scan
       - [git-clone, git-clone-oci-ta]
       - init
-      - [prefetch-dependencies, prefetch-dependencies-oci-ta]
       - rpms-signature-scan
       - [sast-coverity-check, sast-coverity-check-oci-ta]
       - [sast-shell-check, sast-shell-check-oci-ta]
@@ -211,7 +198,6 @@ required-tasks:
       - clamav-scan
       - [git-clone, git-clone-oci-ta]
       - init
-      - [prefetch-dependencies, prefetch-dependencies-oci-ta]
       - rpms-signature-scan
       - [sast-snyk-check, sast-snyk-check-oci-ta]
       - [source-build, source-build-oci-ta]
@@ -221,7 +207,6 @@ required-tasks:
       - clamav-scan
       - [git-clone, git-clone-oci-ta]
       - init
-      - [prefetch-dependencies, prefetch-dependencies-oci-ta]
       - [sast-snyk-check, sast-snyk-check-oci-ta]
       - [source-build, source-build-oci-ta]
   - effective_on: "2023-12-31T00:00:00Z"
@@ -230,7 +215,6 @@ required-tasks:
       - clamav-scan
       - git-clone
       - init
-      - prefetch-dependencies
       - sast-snyk-check
       - source-build
       - summary


### PR DESCRIPTION
I hit an issue with my EC this week where I wanted to enable hermetic builds and I did not need to use prefetch-dependencies.

The EC job yelled at me because I did not include prefetch-dependencies.

Talking with @ralphbean, he thought that this should not really be required as its a helper task to pull dependencies.

So I am opening this up to discuss if we can drop this from our required task list.