### PR TITLE
Remove sast-coverity-check from required tasks

### DIFF
--- a/data/required_tasks.yml
+++ b/data/required_tasks.yml
@@ -55,7 +55,6 @@ pipeline-required-tasks:
         - init
         - [prefetch-dependencies, prefetch-dependencies-oci-ta]
         - rpms-signature-scan
-        - [sast-coverity-check, sast-coverity-check-oci-ta]
         - [sast-shell-check, sast-shell-check-oci-ta]
         - [sast-snyk-check, sast-snyk-check-oci-ta]
         - [sast-unicode-check, sast-unicode-check-oci-ta]
@@ -106,7 +105,6 @@ pipeline-required-tasks:
         - init
         - [prefetch-dependencies, prefetch-dependencies-oci-ta]
         - rpms-signature-scan
-        - [sast-coverity-check, sast-coverity-check-oci-ta]
         - [sast-shell-check, sast-shell-check-oci-ta]
         - [sast-snyk-check, sast-snyk-check-oci-ta]
         - [sast-unicode-check, sast-unicode-check-oci-ta]
@@ -157,7 +155,6 @@ pipeline-required-tasks:
         - [prefetch-dependencies, prefetch-dependencies-oci-ta]
         - rpms-signature-scan
         - s2i-nodejs
-        - [sast-coverity-check, sast-coverity-check-oci-ta]
         - [sast-shell-check, sast-shell-check-oci-ta]
         - [sast-snyk-check, sast-snyk-check-oci-ta]
         - [sast-unicode-check, sast-unicode-check-oci-ta]
@@ -208,7 +205,6 @@ required-tasks:
       - init
       - [prefetch-dependencies, prefetch-dependencies-oci-ta]
       - rpms-signature-scan
-      - [sast-coverity-check, sast-coverity-check-oci-ta]
       - [sast-shell-check, sast-shell-check-oci-ta]
       - [sast-snyk-check, sast-snyk-check-oci-ta]
       - [sast-unicode-check, sast-unicode-check-oci-ta]


### PR DESCRIPTION
For several reasons[1], the new plan is to not make this one a required task at the end of the month. The other two sast tasks will continue be required once the effective date arrives.

This decision was discussed in slack recently and approved by (Product Security team members) Rogue and sfowler.

IIUC we'll still promote the sast-coverity-check, and invite teams to use it, but we'll hold off on making it strictly required. It may still become a required task at some point in the future.

[1] Reasons AIUI:
* Users need to set up their Coverity credential and related secret to use the Coverity check. With the credential not present, the task produces a "skipped" result, which causes Conforma to produce a violation since it doesn't allow required tasks to be skipped.
* Since the task adds an full additional build to the pipeline, it's adding a lot of time to the build pipeline, which is undesirable for some teams already sensitive to the time taken to run the build pipeline.

Ref: https://issues.redhat.com/browse/EC-872
Ref: https://issues.redhat.com/browse/EC-1063