### PR TITLE
Add coverity-availability-check to informative_tests

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -120,6 +120,8 @@ rule_data:
   - ecosystem-cert-preflight-checks
   - fips-operator-bundle-check
   - fips-operator-bundle-check-oci-ta
+  - coverity-availability-check
+  - coverity-availability-check-oci-ta
   - sast-coverity-check
   - sast-coverity-check-oci-ta
   - sast-shell-check


### PR DESCRIPTION
The intent of this change is prevent pipelines from failing when this task reports FAILURE status. The coverity-availability-check task is only intended to check if required secrets are present before trying to run sast-coverity-check. The coverity-availability-check task will report failure to users if the required secrets are not present, and the sast-coverity-check task will be skipped.

Based on errors like:

```
The Task "coverity-availability-check" from the build Pipeline reports a failed test Title: No tests failed Description: Produce a violation if any non-informative tests have their result set to "FAILED". The result type is configurable by the "failed_tests_results" key, and the list of informative tests is configurable by the "informative_tests" key in the rule data. To exclude this rule add "[test.no](http://test.no/)_failed_tests:coverity-availability-check" to the `exclude` section of the policy configuration. Solution: There is a test that failed. Make sure that any task in the build pipeline with a result named 'TEST_OUTPUT' does not fail. More information about the test should be available in the logs for the build Pipeline.
```