### PR TITLE
Make coverity-availability-check informative

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -117,6 +117,7 @@ rule_data:
 
   # https://enterprisecontract.dev/docs/ec-policies/release_policy.html#test_package
   informative_tests:
+  - coverity-availability-check
   - ecosystem-cert-preflight-checks
   - fips-operator-bundle-check
   - fips-operator-bundle-check-oci-ta


### PR DESCRIPTION
This task is for deciding if it's possible to run the sast-coverity-check, so it doesn't really make sense for Conforma to produce a violation if that task produces a failure status.

Actually the idea that the task uses the TEST_OUTPUT task result might be reconsidered, but in the short term, let's make sure a failure status for this task doesn't produce a Conforma violation.

See also:
- https://groups.google.com/a/redhat.com/g/konflux-announce/c/OEcuK1Sr7dI/m/xKwD_bMcAQAJ
- https://github.com/konflux-ci/build-definitions/pull/2027
- https://issues.redhat.com/browse/KONFLUX-2264