### PR TITLE
add ubi9 appstream and baseos repositories

### DIFF
--- a/data/known_rpm_repositories.yml
+++ b/data/known_rpm_repositories.yml
@@ -10568,4 +10568,6 @@ rule_data:
     - "ubi-9-for-x86_64-baseos-debug-rpms"
     - "ubi-9-for-x86_64-baseos-rpms"
     - "ubi-9-for-x86_64-baseos-source-rpms"
+    - "ubi-9-appstream-rpms"
+    - "ubi-9-baseos-rpms"
     - "web-terminal-textonly-1-for-middleware-rpms"


### PR DESCRIPTION
This PR adds 2 repositories to known repository list:
    - "ubi-9-appstream-rpms"
    - "ubi-9-baseos-rpms"

This will deblock the release of Openshift Lightspeed that builds its images using RPM packages from these repositories.

The related EC error messages are:
```
✕ [Violation] rpm_repos.ids_known
  ImageRef: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service@sha256:dfacbb51fbc4e084a4527c40fd75b829321edf201c738d826d79b17536d6f70c
  Reason: RPM repo id check failed: An RPM component in the SBOM specified an unknown or disallowed repository_id:
  pkg:rpm/redhat/gzip@1.12-1.el9?arch=x86_64&checksum=sha256:c8b3e0414d55b1eedb0185a564ac6cb2368bee2fd5f995447d045f6a714488ac&repository_id=ubi-9-baseos-rpms
  (21 additional similar violations not separately listed)
  Title: All rpms have known repo ids
  Description: Each RPM package listed in an SBOM must specify the repository id that it comes from, and that repository id must
  be present in the list of known and permitted repository ids. Currently this is rule enforced only for SBOM components created
  by cachi2. To exclude this rule add
  "rpm_repos.ids_known:pkg:rpm/redhat/gzip@1.12-1.el9?arch=x86_64&checksum=sha256:c8b3e0414d55b1eedb0185a564ac6cb2368bee2fd5f995447d045f6a714488ac&repository_id=ubi-9-baseos-rpms"
  to the `exclude` section of the policy configuration.
  Solution: Ensure every rpm comes from a known and permitted repository, and that the data in the SBOM correctly records that.

✕ [Violation] rpm_repos.ids_known
  ImageRef: quay.io/redhat-user-workloads/crt-nshift-lightspeed-tenant/ols/lightspeed-service@sha256:dfacbb51fbc4e084a4527c40fd75b829321edf201c738d826d79b17536d6f70c
  Reason: RPM repo id check failed: An RPM component in the SBOM specified an unknown or disallowed repository_id:
  pkg:rpm/redhat/libnsl2@2.0.0-1.el9?arch=aarch64&checksum=sha256:5b38c8b55dbfc549271617e132d2d98ceaa9ca30711f73edd8b39a6af689de27&repository_id=ubi-9-appstream-rpms
  (21 additional similar violations not separately listed)
  Title: All rpms have known repo ids
  Description: Each RPM package listed in an SBOM must specify the repository id that it comes from, and that repository id must
  be present in the list of known and permitted repository ids. Currently this is rule enforced only for SBOM components created
  by cachi2. To exclude this rule add
  "rpm_repos.ids_known:pkg:rpm/redhat/libnsl2@2.0.0-1.el9?arch=aarch64&checksum=sha256:5b38c8b55dbfc549271617e132d2d98ceaa9ca30711f73edd8b39a6af689de27&repository_id=ubi-9-appstream-rpms"
  to the `exclude` section of the policy configuration.
  Solution: Ensure every rpm comes from a known and permitted repository, and that the data in the SBOM correctly records that.
```