### PR TITLE
Add operator-sdk-builder to allowed base imges

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -9,6 +9,7 @@ rule_data:
   - quay.io/konflux-ci/yq
   - quay.io/konflux-ci/bazel5-ubi8
   - quay.io/konflux-ci/bazel6-ubi9
+  - quay.io/konflux-ci/operator-sdk-builder
   - quay.io/konflux-ci/yarn3-nodejs20-ubi9-minimal
   - quay.io/konflux-ci/yarn4-nodejs22-ubi9-minimal
   - brew.registry.redhat.io/rh-osbs/rhacm2-nodejs-parent


### PR DESCRIPTION
operator-sdk-builder is an image that provides all the tooling needed to generate operator bundles. It is fully maintained by Red Hat and only contains content produced by Red Hat.

See https://github.com/konflux-ci/operator-sdk-builder

Related: [KONFLUX-5108](https://issues.redhat.com/browse/KONFLUX-5108), [EC-1295](https://issues.redhat.com/browse/EC-1295)