### PR TITLE
Update Hermeto disallowed_attributes policy

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -222,6 +222,10 @@ rule_data:
       value: "true"
     - name: cachi2:pip:package:binary
       value: "true"
+    - name: hermeto:bundler:package:binary
+      value: "true"
+    - name: hermeto:pip:package:binary
+      value: "true"
 
   # No releases on Fridays and weekends
   # https://conforma.dev/docs/policy/packages/release_schedule.html#schedule__weekday_restriction


### PR DESCRIPTION
- Hermeto also supports prefetching binary dependencies for Ruby. We should disallow these by default just like we already do with Python.
- Cachi2 was renamed to Hermeto. We need to support disallowed_attributes for binary dependencies under both the old and new names.