### PR TITLE
Add trusted task rule data to allow konflux-ci tekton-catalog

### DIFF
--- a/data/trusted_task_rules.yaml
+++ b/data/trusted_task_rules.yaml
@@ -1,0 +1,4 @@
+trusted_task_rules:
+  allow:
+    - name: Implicitly trust all tasks from konflux-ci/tekton-catalog
+      pattern: oci://quay.io/konflux-ci/tekton-catalog/*


### PR DESCRIPTION
Add a new `trusted_task_rules` section to rule_data.yml with an allow rule that trusts all tasks from oci://quay.io/konflux-ci/tekton-catalog/

### Do not merge!
**Due to the global scope of the change in this PR, we have decided to defer the merge until after the end-of-year break (mid-January). This ensures we have full team capacity to provide support and avoids catching the users by surprise.**


* This PR depends on the changes in https://github.com/conforma/policy/pull/1595 to be merged first.

Ref: https://issues.redhat.com/browse/EC-1539
Assisted-by: Cursor (using claude-4.5-sonnet)