### PR TITLE
Add rust builder to allowed base image list

### DIFF
--- a/data/known_rpm_repositories.yml
+++ b/data/known_rpm_repositories.yml
@@ -3169,6 +3169,9 @@ rule_data:
     - "rhceph-7-tools-for-rhel-9-x86_64-debug-rpms"
     - "rhceph-7-tools-for-rhel-9-x86_64-rpms"
     - "rhceph-7-tools-for-rhel-9-x86_64-source-rpms"
+    - "rhceph-8-tools-for-rhel-8-aarch64-debug-rpms"
+    - "rhceph-8-tools-for-rhel-8-aarch64-rpms"
+    - "rhceph-8-tools-for-rhel-8-aarch64-source-rpms"
     - "rhceph-8-tools-for-rhel-8-ppc64le-debug-rpms"
     - "rhceph-8-tools-for-rhel-8-ppc64le-rpms"
     - "rhceph-8-tools-for-rhel-8-ppc64le-source-rpms"
@@ -3178,9 +3181,9 @@ rule_data:
     - "rhceph-8-tools-for-rhel-8-x86_64-debug-rpms"
     - "rhceph-8-tools-for-rhel-8-x86_64-rpms"
     - "rhceph-8-tools-for-rhel-8-x86_64-source-rpms"
-    - rhceph-8-tools-for-rhel-9-aarch64-debug-rpms
-    - rhceph-8-tools-for-rhel-9-aarch64-rpms
-    - rhceph-8-tools-for-rhel-9-aarch64-source-rpms
+    - "rhceph-8-tools-for-rhel-9-aarch64-debug-rpms"
+    - "rhceph-8-tools-for-rhel-9-aarch64-rpms"
+    - "rhceph-8-tools-for-rhel-9-aarch64-source-rpms"
     - "rhceph-8-tools-for-rhel-9-ppc64le-debug-rpms"
     - "rhceph-8-tools-for-rhel-9-ppc64le-rpms"
     - "rhceph-8-tools-for-rhel-9-ppc64le-source-rpms"

--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -13,6 +13,7 @@ rule_data:
   - quay.io/konflux-ci/yarn3-nodejs20-ubi9-minimal
   - quay.io/konflux-ci/yarn4-nodejs22-ubi9-minimal
   - quay.io/konflux-ci/git-clone
+  - quay.io/konflux-ci/rust-builder
   - brew.registry.redhat.io/rh-osbs/openshift-golang-builder
   - brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9
   - brew.registry.redhat.io/rh-osbs/rhacm2-nodejs-parent


### PR DESCRIPTION
Motivated by the slack thread from
https://issues.redhat.com/browse/KFLUXSPRT-7080 .

See also:
* https://github.com/konflux-ci/rust-builder
* https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/rust-sig-tenant/applications/rust-builder/

Note that this won't take effect if you defined a custom allowed_registry_prefixes list in your ECP.

(Second commit unrelated, but needed to make the CI turn green.)