### PR TITLE
Add trusted task rule data to allow konflux-ci tekton-catalog

### DIFF
--- a/data/trusted_task_rules.yml
+++ b/data/trusted_task_rules.yml
@@ -1,0 +1,5 @@
+rule_data:
+  trusted_task_rules:
+    allow:
+      - name: Implicitly trust all tasks from konflux-ci/tekton-catalog
+        pattern: oci://quay.io/konflux-ci/tekton-catalog/*


### PR DESCRIPTION
Add a new trusted_task_rules section to rule_data.yml with an allow rule that trusts all tasks from
oci://quay.io/konflux-ci/tekton-catalog/.

Ref: https://issues.redhat.com/browse/EC-1539 (original story)
Ref: https://github.com/release-engineering/rhtap-ec-policy/pull/195 (original PR)
Ref: https://issues.redhat.com/browse/EC-1540