### PR TITLE
Add quay.io/hummingbird/ to allowed_registry_prefixes

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -16,6 +16,7 @@ rule_data:
   - brew.registry.redhat.io/rh-osbs/openshift-golang-builder
   - brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9
   - brew.registry.redhat.io/rh-osbs/rhacm2-nodejs-parent
+  - quay.io/hummingbird/
 
   allowed_olm_image_registry_prefixes:
   - registry.access.redhat.com/


### PR DESCRIPTION
## Summary

- Add `quay.io/hummingbird/` to `allowed_registry_prefixes` in `rule_data.yml`

[Hummingbird](https://gitlab.com/redhat/hummingbird/containers) is Red Hat's distroless container image project. Teams building with Konflux need to use these as base images for FIPS-compliant distroless builds. Currently the EC `base_image_registries.base_image_permitted` rule rejects `quay.io/hummingbird/python` as an untrusted registry.

Hummingbird RPM repo IDs (`public-hummingbird-*-rpms`) are already approved in `known_rpm_repositories.yml`, so the registry prefix is the only missing piece.