### PR TITLE
Add workflow to push OPA data bundle to Quay

### DIFF
--- a/.github/workflows/push-data-bundle.yaml
+++ b/.github/workflows/push-data-bundle.yaml
@@ -1,0 +1,34 @@
+name: Push data bundle
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "data/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  push-data-bundle:
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/conforma/cli:latest
+    env:
+      DATA_BUNDLE_REPO: quay.io/conforma/policy-data
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Login to Quay
+        run: |
+          ec opa login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io
+
+      - name: Build and push data bundle
+        run: |
+          DATA_BUNDLE_TAG=$(date '+%s')
+          ec opa build -b data/ -o bundle.tar.gz
+          ec opa push "${DATA_BUNDLE_REPO}:${DATA_BUNDLE_TAG}" bundle.tar.gz
+          ec opa push "${DATA_BUNDLE_REPO}:latest" bundle.tar.gz

--- a/.github/workflows/push-data-bundle.yaml
+++ b/.github/workflows/push-data-bundle.yaml
@@ -14,21 +14,33 @@ permissions:
 jobs:
   push-data-bundle:
     runs-on: ubuntu-latest
-    container:
-      image: quay.io/conforma/cli:latest
     env:
       DATA_BUNDLE_REPO: quay.io/conforma/policy-data
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Login to Quay
-        run: |
-          ec opa login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io
+      - name: Install ec-cli
+        run: |-
+          mkdir -p "${HOME}/.local/bin"
+          curl -sL https://github.com/enterprise-contract/ec-cli/releases/download/snapshot/ec_linux_amd64 -o "${HOME}/.local/bin/ec"
+          chmod +x "${HOME}/.local/bin/ec"
+          ec version
 
-      - name: Build and push data bundle
+      - name: Install oras
+        run: |-
+          ORAS_VERSION="1.2.2"
+          curl -sL "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz" | tar xz -C "${HOME}/.local/bin" oras
+          oras version
+
+      - name: Build OPA data bundle
+        run: ec opa build -b data/ -o bundle.tar.gz
+
+      - name: Login to Quay
+        run: oras login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io
+
+      - name: Push data bundle
         run: |
           DATA_BUNDLE_TAG=$(date '+%s')
-          ec opa build -b data/ -o bundle.tar.gz
-          ec opa push "${DATA_BUNDLE_REPO}:${DATA_BUNDLE_TAG}" bundle.tar.gz
-          ec opa push "${DATA_BUNDLE_REPO}:latest" bundle.tar.gz
+          oras push "${DATA_BUNDLE_REPO}:${DATA_BUNDLE_TAG}" bundle.tar.gz
+          oras push "${DATA_BUNDLE_REPO}:latest" bundle.tar.gz


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that builds an OPA data bundle from the `data/` directory and pushes it to `quay.io/conforma/policy-data`.

- Triggers on push to `main` (when `data/**` files change) and on manual `workflow_dispatch`
- Uses `ec opa build` to create the bundle tarball
- Uses `oras` to push the bundle to Quay with a timestamp tag and floating `latest` tag
- Quay credentials are stored as `QUAY_USERNAME` and `QUAY_PASSWORD` repository secrets (set up in EC-1826)

## Prerequisites

- Quay repo `quay.io/conforma/policy-data` (created in EC-1826)
- Robot account `conforma+policy_data_push` with Write access (created in EC-1826)
- GitHub secrets `QUAY_USERNAME` and `QUAY_PASSWORD` (configured in EC-1826)

## Test plan

- [ ] Verify workflow YAML is valid
- [ ] Merge and confirm the workflow runs successfully on push to main
- [ ] Verify the bundle appears in `quay.io/conforma/policy-data` with correct tags

Ref: https://redhat.atlassian.net/browse/EC-1827
Parent: https://redhat.atlassian.net/browse/EC-1825