### PR TITLE
Add workflow to push OPA data bundle to Quay 

### DIFF
--- a/.github/workflows/push-data-bundle.yaml
+++ b/.github/workflows/push-data-bundle.yaml
@@ -14,23 +14,18 @@ permissions:
 jobs:
   push-data-bundle:
     runs-on: ubuntu-latest
+    container:
+      image: quay.io/conforma/cli:latest
     env:
       DATA_BUNDLE_REPO: quay.io/conforma/policy-data
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install ec-cli
-        run: |-
-          mkdir -p "${HOME}/.local/bin"
-          curl -sL https://github.com/conforma/cli/releases/download/snapshot/ec_linux_amd64 -o "${HOME}/.local/bin/ec"
-          chmod +x "${HOME}/.local/bin/ec"
-          ec version
-
       - name: Install oras
         run: |-
           ORAS_VERSION="1.2.2"
-          curl -sL "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz" | tar xz -C "${HOME}/.local/bin" oras
+          curl -sL "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz" | tar xz -C /usr/local/bin oras
           oras version
 
       - name: Build OPA bundle and extract merged data.json

--- a/.github/workflows/push-data-bundle.yaml
+++ b/.github/workflows/push-data-bundle.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Install ec-cli
         run: |-
           mkdir -p "${HOME}/.local/bin"
-          curl -sL https://github.com/enterprise-contract/ec-cli/releases/download/snapshot/ec_linux_amd64 -o "${HOME}/.local/bin/ec"
+          curl -sL https://github.com/conforma/cli/releases/download/snapshot/ec_linux_amd64 -o "${HOME}/.local/bin/ec"
           chmod +x "${HOME}/.local/bin/ec"
           ec version
 
@@ -33,7 +33,7 @@ jobs:
           curl -sL "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz" | tar xz -C "${HOME}/.local/bin" oras
           oras version
 
-      - name: Build and extract OPA data bundle
+      - name: Build OPA bundle and extract merged data.json
         run: |
           ec opa build data/ -o bundle.tar.gz
           tar xzf bundle.tar.gz -C .

--- a/.github/workflows/push-data-bundle.yaml
+++ b/.github/workflows/push-data-bundle.yaml
@@ -34,7 +34,7 @@ jobs:
           oras version
 
       - name: Build OPA data bundle
-        run: ec opa build -b data/ -o bundle.tar.gz
+        run: ec opa build data/ -o bundle.tar.gz
 
       - name: Login to Quay
         run: oras login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io

--- a/.github/workflows/push-data-bundle.yaml
+++ b/.github/workflows/push-data-bundle.yaml
@@ -1,0 +1,46 @@
+name: Push data bundle
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "data/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  push-data-bundle:
+    runs-on: ubuntu-latest
+    env:
+      DATA_BUNDLE_REPO: quay.io/conforma/policy-data
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install ec-cli
+        run: |-
+          mkdir -p "${HOME}/.local/bin"
+          curl -sL https://github.com/enterprise-contract/ec-cli/releases/download/snapshot/ec_linux_amd64 -o "${HOME}/.local/bin/ec"
+          chmod +x "${HOME}/.local/bin/ec"
+          ec version
+
+      - name: Install oras
+        run: |-
+          ORAS_VERSION="1.2.2"
+          curl -sL "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz" | tar xz -C "${HOME}/.local/bin" oras
+          oras version
+
+      - name: Build OPA data bundle
+        run: ec opa build -b data/ -o bundle.tar.gz
+
+      - name: Login to Quay
+        run: oras login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io
+
+      - name: Push data bundle
+        run: |
+          DATA_BUNDLE_TAG=$(date '+%s')
+          oras push "${DATA_BUNDLE_REPO}:${DATA_BUNDLE_TAG}" bundle.tar.gz
+          oras push "${DATA_BUNDLE_REPO}:latest" bundle.tar.gz

--- a/.github/workflows/push-data-bundle.yaml
+++ b/.github/workflows/push-data-bundle.yaml
@@ -33,8 +33,10 @@ jobs:
           curl -sL "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz" | tar xz -C "${HOME}/.local/bin" oras
           oras version
 
-      - name: Build OPA data bundle
-        run: ec opa build data/ -o bundle.tar.gz
+      - name: Build and extract OPA data bundle
+        run: |
+          ec opa build data/ -o bundle.tar.gz
+          tar xzf bundle.tar.gz data.json
 
       - name: Login to Quay
         run: oras login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io
@@ -42,5 +44,5 @@ jobs:
       - name: Push data bundle
         run: |
           DATA_BUNDLE_TAG=$(date '+%s')
-          oras push "${DATA_BUNDLE_REPO}:${DATA_BUNDLE_TAG}" bundle.tar.gz
-          oras push "${DATA_BUNDLE_REPO}:latest" bundle.tar.gz
+          oras push "${DATA_BUNDLE_REPO}:${DATA_BUNDLE_TAG}" data.json:application/vnd.cncf.openpolicyagent.data.layer.v1+json
+          oras push "${DATA_BUNDLE_REPO}:latest" data.json:application/vnd.cncf.openpolicyagent.data.layer.v1+json

--- a/.github/workflows/push-data-bundle.yaml
+++ b/.github/workflows/push-data-bundle.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Build and extract OPA data bundle
         run: |
           ec opa build data/ -o bundle.tar.gz
-          tar xzf bundle.tar.gz data.json
+          tar xzf bundle.tar.gz -C .
 
       - name: Login to Quay
         run: oras login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that builds an OPA data bundle from the `data/` directory and pushes it to `quay.io/conforma/policy-data`.

- Triggers on push to `main` (when `data/**` files change) and on manual `workflow_dispatch`
- Uses `ec opa build` to create the bundle tarball
- Uses `oras` to push the bundle to Quay with a timestamp tag and floating `latest` tag
- Quay credentials are stored as `QUAY_USERNAME` and `QUAY_PASSWORD` repository secrets (set up in EC-1826)

## Prerequisites

- Quay repo `quay.io/conforma/policy-data` (created in EC-1826)
- Robot account `conforma+policy_data_push` with Write access (created in EC-1826)
- GitHub secrets `QUAY_USERNAME` and `QUAY_PASSWORD` (configured in EC-1826)


Ref: https://redhat.atlassian.net/browse/EC-1827