### PR TITLE
Add disk-image pipeline to required tasks

### DIFF
--- a/data/required_tasks.yml
+++ b/data/required_tasks.yml
@@ -90,6 +90,17 @@ pipeline-required-tasks:
         - source-build-oci-ta
         - sast-shell-check-oci-ta
         - sast-unicode-check-oci-ta
+  disk-image:
+    - effective_on: "2026-05-28T00:00:00Z"
+      tasks:
+        - init
+        - git-clone-oci-ta
+        - prefetch-dependencies-oci-ta
+        - build-vm-image
+        - build-image-index
+        - sast-shell-check-oci-ta
+        - sast-snyk-check-oci-ta
+        - sast-unicode-check-oci-ta
 
 
 # https://conforma.dev/docs/policy/packages/release_tasks.html


### PR DESCRIPTION
## Summary

- Adds a `disk-image` entry to `pipeline-required-tasks` for the disk-image build pipeline used by RHEL AI bootc disk image builds
- The disk-image pipeline uses `build-vm-image` instead of `buildah` and does not include container-specific scanning tasks (clair-scan, clamav-scan, rpms-signature-scan, deprecated-image-check)
- Without this entry, conforma falls back to `docker`/`generic` required task lists which mandate buildah and deprecated-image-check, forcing teams to maintain permanent ECP exceptions

## Tasks included

`init`, `git-clone-oci-ta`, `prefetch-dependencies-oci-ta`, `build-vm-image`, `build-image-index`, `sast-shell-check-oci-ta`, `sast-snyk-check-oci-ta`, `sast-unicode-check-oci-ta`

## Test plan

- [ ] Verify `build-vm-image` task has label `build_type: disk-image` matching this entry
- [ ] Run conforma validation against a disk-image build with this data to confirm buildah exceptions are no longer needed

Signed-off-by: Víctor M. Múgica <vmugicag@redhat.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)