### PR TITLE
Add RBAC exceptions for ART layered-product operators

### DIFF
--- a/data/operator_network_policy_rbac_exceptions.yml
+++ b/data/operator_network_policy_rbac_exceptions.yml
@@ -148,6 +148,7 @@ rule_data:
       - "6.3"
       - "6.4"
       - "6.5"
+      - "6.6"
     cluster-observability-operator:
       - "1.0"
       - "1.1"
@@ -524,6 +525,7 @@ rule_data:
       - "6.3"
       - "6.4"
       - "6.5"
+      - "6.6"
     lvms-operator:
       - "4.12"
       - "4.13"
@@ -588,6 +590,7 @@ rule_data:
       - "7.3"
       - "8.0"
       - "8.1"
+      - "8.2"
     mtc-operator:
       - "1.7"
       - "1.8"
@@ -997,6 +1000,7 @@ rule_data:
       - "1.3"
       - "1.4"
       - "1.5"
+      - "1.6"
     rh-service-binding-operator:
       - "0.10"
       - "0.11"


### PR DESCRIPTION
Add version 6.6 to cluster-logging and loki-operator, version 8.2 to mta-operator, and version 1.6 to redhat-oadp-operator.

Signed-off-by: Rayford Johnson <rayfordj@users.noreply.github.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

These are y-stream versions expected to GA ahead of August-8th blocker for "Conforma policy for Operator bundles: `olm.required_network_policy_rbac_for_operands`."