### PR TITLE
Allow binary packages from RHTL python index

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -227,6 +227,10 @@ rule_data:
       value: "true"
     - name: hermeto:pip:package:binary
       value: "true"
+      except_when:
+      - purl_qualifier: repository_url
+        patterns:
+        - "^https://packages\\.redhat\\.com/trusted-libraries/python/.*"
 
   # No releases on Fridays and weekends
   # https://conforma.dev/docs/policy/packages/release_schedule.html#schedule__weekday_restriction


### PR DESCRIPTION
These packages are built from source within Red Hat's Konflux instances. They meet strong security levels making their binaries acceptable for consumption.

Requires https://github.com/conforma/policy/pull/1739