### PR TITLE
chore: remove redhat-appstudio step image registry prefix

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -22,7 +22,6 @@ rule_data:
   - registry.redhat.io/
 
   allowed_step_image_registry_prefixes:
-  - quay.io/redhat-appstudio/
   - quay.io/konflux-ci/
   - registry.access.redhat.com/
   - registry.redhat.io/


### PR DESCRIPTION
Once [this PR](https://github.com/konflux-ci/build-definitions/pull/3592) is merged, the `appstudio-utils` image will no longer be built. We also need to remove `quay.io/redhat-appstudio/` from the allowed_step_image_registry_prefixes. Users have been expected to use `konflux-ci` instead of `redhat-appstudio` for about a year now, so this is safe to delete.