### PR TITLE
add ZTWIM 1.0.1, 1.0.2 and 1.1 to network policy rbac exceptions

### DIFF
--- a/data/operator_network_policy_rbac_exceptions.yml
+++ b/data/operator_network_policy_rbac_exceptions.yml
@@ -897,6 +897,9 @@ rule_data:
       - "0.1"
       - "0.2"
       - "1.0"
+      - "1.0.1"
+      - "1.0.2"
+      - "1.1"
     openstack-ansibleee-operator:
       - "1.0"
     openstack-baremetal-operator:


### PR DESCRIPTION
Add network policy RBAC exceptions for zero-trust-workload-identity-manager 1.0.1, 1.0.2, and 1.1

The zero-trust-workload-identity-manager operator does not yet include network policy RBAC support. Version 1.0.1 has already been released, and versions 1.0.2 and 1.1 are already scoped for their respective releases. Network policy RBAC will be addressed in the 1.2 GA release (planned for OCP 5.0). Adding exceptions for these versions to unblock their releases.