### PR TITLE
EC-1963: Fix container permissions for push-data-bundle workflow

### DIFF
--- a/.github/workflows/push-data-bundle.yaml
+++ b/.github/workflows/push-data-bundle.yaml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: quay.io/konflux-ci/task-runner:v1
+      options: --user root
     env:
       DATA_BUNDLE_REPO: quay.io/conforma/policy-data
     steps:


### PR DESCRIPTION
## Summary

The push-data-bundle workflow fails with `EACCES: permission denied` during checkout because `task-runner:v1` runs as a non-root user. `actions/checkout` needs write access to runner temp directories.

Fix: add `options: --user root` to the container config.

Failed run: https://github.com/release-engineering/rhtap-ec-policy/actions/runs/28532081636

Ref: https://redhat.atlassian.net/browse/EC-1963