### PR TITLE
EC-1963: Fix ec-cli install path for root user

### DIFF
--- a/.github/workflows/push-data-bundle.yaml
+++ b/.github/workflows/push-data-bundle.yaml
@@ -25,9 +25,8 @@ jobs:
 
       - name: Install ec-cli
         run: |-
-          mkdir -p "${HOME}/.local/bin"
-          curl -sL https://github.com/conforma/cli/releases/download/snapshot/ec_linux_amd64 -o "${HOME}/.local/bin/ec"
-          chmod +x "${HOME}/.local/bin/ec"
+          curl -sL https://github.com/conforma/cli/releases/download/snapshot/ec_linux_amd64 -o /usr/local/bin/ec
+          chmod +x /usr/local/bin/ec
           ec version
 
       - name: Build OPA bundle and extract merged data.json


### PR DESCRIPTION
## Summary

The push-data-bundle workflow fails at `ec: command not found` because `${HOME}/.local/bin` isn't in PATH when running as root. Install ec-cli to `/usr/local/bin` instead.

Tested end-to-end in the task-runner container with `--user root` — all steps pass including Quay push and `ec inspect policy-data` verification.

Failed run: https://github.com/release-engineering/rhtap-ec-policy/actions/runs/28533428397

Ref: https://redhat.atlassian.net/browse/EC-1963