### PR TITLE
Add RHWA 4.22 operator versions to network policy RBAC exceptions

### DIFF
--- a/data/operator_network_policy_rbac_exceptions.yml
+++ b/data/operator_network_policy_rbac_exceptions.yml
@@ -329,6 +329,7 @@ rule_data:
       - "0.5"
       - "0.6"
       - "0.7"
+      - "0.8"
     file-integrity-operator:
       - "0.1"
       - "1.0"
@@ -552,6 +553,7 @@ rule_data:
       - "0.4"
       - "0.5"
       - "0.6"
+      - "0.7"
     manila-operator:
       - "1.0"
     mariadb-operator:
@@ -678,6 +680,7 @@ rule_data:
     node-healthcheck-operator:
       - "0.10"
       - "0.11"
+      - "0.12"
       - "0.3"
       - "0.4"
       - "0.6"
@@ -691,6 +694,7 @@ rule_data:
       - "5.4"
       - "5.5"
       - "5.6"
+      - "5.7"
     node-observability-operator:
       - "0.2"
     nova-operator:
@@ -1179,6 +1183,7 @@ rule_data:
       - "0.10"
       - "0.11"
       - "0.12"
+      - "0.13"
       - "0.5"
       - "0.7"
       - "0.8"
@@ -1260,6 +1265,7 @@ rule_data:
       - "0.1"
     storage-based-remediation:
       - "0.2"
+      - "0.3"
     submariner:
       - "0.13"
       - "0.14"


### PR DESCRIPTION
## Summary

Add the current RHWA (Red Hat Workload Availability) operator minor versions shipped in OCP 4.22 to the exception list:

- `fence-agents-remediation`: 0.8
- `machine-deletion-remediation`: 0.7
- `node-healthcheck-operator`: 0.12
- `node-maintenance-operator`: 5.7
- `self-node-remediation`: 0.13
- `storage-based-remediation`: 0.3

These versions were released before the NetworkPolicy RBAC requirement was introduced. They were not included in the initial exception list (generated from `redhat-operator-index:v4.21`) because 4.22 versions didn't exist at that time.

Without this exception, z-stream patch releases for these versions will be blocked by the `olm.required_network_policy_rbac_for_operands` Conforma check after August 7, 2026. We are planning patch releases (e.g. 0.8.1, 0.3.1) in the coming weeks that may land after the enforcement date.

### Evidence: current EC warnings on these bundles

All 6 operators currently show the `olm.required_network_policy_rbac_for_operands` warning in their Conforma checks. Yesterday's (Jul 21) passing runs with these warnings:

- FAR 0.8: [far-0-8-enterprise-contract-xp97k](https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhwa-tenant/pipelinerun/far-0-8-enterprise-contract-xp97k)
- MDR 0.7: [mdr-0-7-enterprise-contract-khw8x](https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhwa-tenant/pipelinerun/mdr-0-7-enterprise-contract-khw8x)
- NHC 0.12: [nhc-0-12-enterprise-contract-qwpb2](https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhwa-tenant/pipelinerun/nhc-0-12-enterprise-contract-qwpb2)
- NMO 5.7: [nmo-5-7-enterprise-contract-d5zwp](https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhwa-tenant/pipelinerun/nmo-5-7-enterprise-contract-d5zwp)
- SNR 0.13: [snr-0-13-enterprise-contract-996xf](https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhwa-tenant/pipelinerun/snr-0-13-enterprise-contract-996xf)
- SBR 0.3: [sbr-0-3-enterprise-contract-g86d4](https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhwa-tenant/pipelinerun/sbr-0-3-enterprise-contract-g86d4)

Related: [CLOUDDST-32701](https://redhat.atlassian.net/browse/CLOUDDST-32701) (exempting operators without operands — FAR, MDR, NMO have no operands)

## Risk Assessment

Medium — we plan patch releases (z-streams) for these versions in the coming weeks. Without this exception, those releases will be blocked if they ship after August 7, 2026.