### PR TITLE
Add OCI annotations to data bundle push

### DIFF
--- a/.github/workflows/push-data-bundle.yaml
+++ b/.github/workflows/push-data-bundle.yaml
@@ -39,6 +39,9 @@ jobs:
 
       - name: Push data bundle
         run: |
+          ANNOTATIONS="--annotation org.opencontainers.image.source=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+          ANNOTATIONS="${ANNOTATIONS} --annotation org.opencontainers.image.revision=${GITHUB_SHA}"
+          ANNOTATIONS="${ANNOTATIONS} --annotation org.opencontainers.image.url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${GITHUB_SHA}/data"
           DATA_BUNDLE_TAG=$(date '+%s')
-          oras push "${DATA_BUNDLE_REPO}:${DATA_BUNDLE_TAG}" data.json:application/vnd.cncf.openpolicyagent.data.layer.v1+json
-          oras push "${DATA_BUNDLE_REPO}:latest" data.json:application/vnd.cncf.openpolicyagent.data.layer.v1+json
+          oras push ${ANNOTATIONS} "${DATA_BUNDLE_REPO}:${DATA_BUNDLE_TAG}" data.json:application/vnd.cncf.openpolicyagent.data.layer.v1+json
+          oras push ${ANNOTATIONS} "${DATA_BUNDLE_REPO}:latest" data.json:application/vnd.cncf.openpolicyagent.data.layer.v1+json


### PR DESCRIPTION
Add OCI annotations to the `oras push` step so the data bundle carries traceability metadata:

- `org.opencontainers.image.source` — link to the source repo
- `org.opencontainers.image.revision` — the git commit SHA that triggered the build
- `org.opencontainers.image.url` — link to the Quay repo

After this, `skopeo inspect --raw docker://quay.io/redhat-konflux/policy-data:latest | jq .annotations` will show the provenance info.

Suggested by @simonbaird.

Jira: https://redhat.atlassian.net/browse/EC-1991