### PR TITLE
Make sure build-dm-verity-image is trusted

### DIFF
--- a/data/trusted_task_rules_deprecated.yaml
+++ b/data/trusted_task_rules_deprecated.yaml
@@ -15,6 +15,14 @@ rule_data:
         # config/stone-prd-rh01.pg1f.p1/product/EnterpriseContractPolicy
         - pattern: oci://quay.io/konflux-ci/ose-osc-tenant/build-dm-verity-image-task
 
+        # Todo: Similarly we're intending to move this matcher so it's only used for
+        # the RoK builds, instead of everyone. Putting it here temporarily so RoK builds
+        # continue to work after we cut over to the the new trusted task mechanism.
+        # See also the following PRs. Once those PRs are merged this could be removed:
+        # - https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline/-/merge_requests/348
+        # - https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/21073
+        - pattern: git+https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline.git//task/*
+
     deny:
       konflux-defaults-deprecated:
         #-------------------------------------

--- a/data/trusted_task_rules_deprecated.yaml
+++ b/data/trusted_task_rules_deprecated.yaml
@@ -9,6 +9,12 @@ rule_data:
         - pattern: oci://quay.io/konflux-ci/integration-service-catalog/task-*
         - pattern: oci://quay.io/konflux-ci/konflux-vanguard/*
 
+        # Todo: This is used by just one team, so it would be better to define
+        # a separate data source that can be referenced in registry-ose-osc-stage.yaml
+        # and registry-ose-osc.yaml in the konflux-release-data repo in
+        # config/stone-prd-rh01.pg1f.p1/product/EnterpriseContractPolicy
+        - pattern: oci://quay.io/konflux-ci/ose-osc-tenant/build-dm-verity-image-task
+
     deny:
       konflux-defaults-deprecated:
         #-------------------------------------
@@ -60,4 +66,12 @@ rule_data:
 
         # rpms-signature-scan
         - pattern: oci://quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan
+          versions: ['<0.1']
+
+        #-------------------------------------
+        # konflux-ci/ose-osc-tenant
+        #-------------------------------------
+
+        # build-dm-verity-image
+        - pattern: oci://quay.io/konflux-ci/ose-osc-tenant/build-dm-verity-image-task
           versions: ['<0.1']


### PR DESCRIPTION
This is a temporary addition to we don't break the ose-osc-tenant team's build pipeline when the new trusted task rules are enabled. (At this stage we're intending to enable the new trusted task rules tomorrow.)

As mentioned in the comments, the longer term plan is to move this trusted task rule data into a separate data source included in just the ECPs where it is needed, specifically these:

- https://gitlab.cee.redhat.com/releng/konflux-release-data/-/blob/main/config/stone-prd-rh01.pg1f.p1/product/EnterpriseContractPolicy/registry-ose-osc.yaml?ref_type=heads
- https://gitlab.cee.redhat.com/releng/konflux-release-data/-/blob/main/config/stone-prd-rh01.pg1f.p1/product/EnterpriseContractPolicy/registry-ose-osc-stage.yaml?ref_type=heads

Once it has been added there we can revert this change.

Ref: https://redhat.atlassian.net/browse/EC-1536