### PR TITLE
Disallow prefetch-dependencies <0.7.1 tasks

### DIFF
--- a/data/trusted_task_rules.yaml
+++ b/data/trusted_task_rules.yaml
@@ -371,27 +371,18 @@ rule_data:
 
         # prefetch-dependencies
         - pattern: oci://quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies
-          versions: ['<0.3']
-          effective_on: "2026-08-06T00:00:00Z"
-        - pattern: oci://quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies
-          versions: ['<0.4']
-          effective_on: "2026-09-05T00:00:00Z"
+          versions: ['<0.7.1']
+          effective_on: "2026-08-11T00:00:00Z"
 
         # prefetch-dependencies-oci-ta
         - pattern: oci://quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta
-          versions: ['<0.3']
-          effective_on: "2026-08-06T00:00:00Z"
-        - pattern: oci://quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta
-          versions: ['<0.4']
-          effective_on: "2026-09-05T00:00:00Z"
+          versions: ['<0.7.1']
+          effective_on: "2026-08-11T00:00:00Z"
 
         # prefetch-dependencies-oci-ta-min
         - pattern: oci://quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta-min
-          versions: ['<0.3']
-          effective_on: "2026-08-06T00:00:00Z"
-        - pattern: oci://quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta-min
-          versions: ['<0.4']
-          effective_on: "2026-09-05T00:00:00Z"
+          versions: ['<0.7.1']
+          effective_on: "2026-08-11T00:00:00Z"
 
         # provision-env-with-ephemeral-namespace
         - pattern: oci://quay.io/konflux-ci/tekton-catalog/task-provision-env-with-ephemeral-namespace


### PR DESCRIPTION
prefetch-dependencies 0.7.1 includes version of Hermeto with security fixes for several CVEs[1].

In order to prevent the possibility of an exploit, let the affected versions expire as soon as possible -- on 2026-08-11T00:00:00Z.

[1]: https://github.com/hermetoproject/hermeto/releases/tag/0.60.1