### PR TITLE
Remove version constraints from show-sbom and summary trusted task rules

### DIFF
--- a/data/trusted_task_rules.yaml
+++ b/data/trusted_task_rules.yaml
@@ -533,7 +533,7 @@ rule_data:
 
         # show-sbom
         - pattern: oci://quay.io/konflux-ci/tekton-catalog/task-show-sbom
-          versions: ['<0.1']
+          effective_on: "2026-09-05T00:00:00Z"
 
         # show-sbom-rhdh
         - pattern: oci://quay.io/konflux-ci/tekton-catalog/task-show-sbom-rhdh
@@ -565,7 +565,6 @@ rule_data:
 
         # summary
         - pattern: oci://quay.io/konflux-ci/tekton-catalog/task-summary
-          versions: ['<0.2']
           effective_on: "2026-09-05T00:00:00Z"
 
         # tkn-bundle


### PR DESCRIPTION
The build team decided to deprecate both tasks during build-definitions decentralization by bumping the task version and attaching a self-removing migration script to the task bundle. The latest versions already expired. This change ensures no one is using the older versions.

The missing `versions` field should deny all versions.

--
https://github.com/konflux-ci/build-definitions/blob/f41d7e4f422304d3deb5bd76bd832d051530a895/task/show-sbom/CHANGELOG.md https://github.com/konflux-ci/build-definitions/blob/f41d7e4f422304d3deb5bd76bd832d051530a895/task/summary/CHANGELOG.md https://github.com/conforma/policy/blob/main/policy/lib/tekton/trusted.rego#L533