### PR TITLE
Push the date for restricting older prefetch task versions

### DIFF
--- a/data/trusted_task_rules.yaml
+++ b/data/trusted_task_rules.yaml
@@ -372,17 +372,17 @@ rule_data:
         # prefetch-dependencies
         - pattern: oci://quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies
           versions: ['<0.7.1']
-          effective_on: "2026-08-12T00:00:00Z"
+          effective_on: "2026-08-13T04:00:00Z"
 
         # prefetch-dependencies-oci-ta
         - pattern: oci://quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta
           versions: ['<0.7.1']
-          effective_on: "2026-08-12T00:00:00Z"
+          effective_on: "2026-08-13T04:00:00Z"
 
         # prefetch-dependencies-oci-ta-min
         - pattern: oci://quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta-min
           versions: ['<0.7.1']
-          effective_on: "2026-08-12T00:00:00Z"
+          effective_on: "2026-08-13T04:00:00Z"
 
         # provision-env-with-ephemeral-namespace
         - pattern: oci://quay.io/konflux-ci/tekton-catalog/task-provision-env-with-ephemeral-namespace


### PR DESCRIPTION
Teams need longer time to react to the changing requirement, this gives a day buffer