### PR TITLE
Add required tasks for the python-formager-build pipeline

### DIFF
--- a/data/required_tasks.yml
+++ b/data/required_tasks.yml
@@ -97,6 +97,13 @@ pipeline-required-tasks:
         - clamav-scan
         - [sast-shell-check, sast-shell-check-oci-ta]
         - [sast-unicode-check, sast-unicode-check-oci-ta]
+  python-fromager-build:
+    - effective_on: "2026-08-18T00:00:00Z"
+      tasks:
+        - git-clone-oci-ta
+        - source-to-sdist
+        - fromager-build-wheels
+        - clamav-scan
 
 # https://conforma.dev/docs/policy/packages/release_tasks.html
 required-tasks:


### PR DESCRIPTION
This is a simplified pipeline that is used in Lightwell for building Python wheels. The set of tasks will likely increase as the pipeline matures, but this is the initial set we require.